### PR TITLE
ci: Only lint on code change

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,6 +2,8 @@ name: Lint and Test Code
 
 on:
   pull_request:
+    paths:
+      - 'src/**'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Why: It's a waste of time to lint and test when no code change was pushed.

What: Changes the pull trigger so it only fires when a file in the `src` directory is changed. This could be even more granular but at this point it's probably fine.