### PR TITLE
feat: Save analytical data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1460,6 +1460,7 @@ dependencies = [
  "opentelemetry_sdk",
  "r2d2",
  "redis",
+ "regex",
  "reqwest 0.12.28",
  "rust-embed",
  "rustls",
@@ -2376,6 +2377,18 @@ dependencies = [
  "proc-macro2 1.0.103",
  "quote 1.0.42",
  "syn 2.0.111",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,3 +43,4 @@ sha2 = "0.10.9"
 rustls = { version = "0.23.35", features = ["ring"] }
 r2d2 = "0.8.10"
 serde_json = "1.0.147"
+regex = "1.12.2"

--- a/examples/new_zkill_format.rs
+++ b/examples/new_zkill_format.rs
@@ -6,6 +6,7 @@ async fn main() -> anyhow::Result<()> {
         kill_id: 12345,
         zkb: krusty::zkb::Zkb {
             href: "https://esi.evetech.net/v1/killmails/130678514/145c457c34ce9c9e8d67e942e764d8f439b22271/".to_string(),
+            ..Default::default()
         },
         killmail: None,
     };

--- a/migrations/2025-12-24-235141-0000_analytics_killmails/down.sql
+++ b/migrations/2025-12-24-235141-0000_analytics_killmails/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE analytics_killmails;

--- a/migrations/2025-12-24-235141-0000_analytics_killmails/up.sql
+++ b/migrations/2025-12-24-235141-0000_analytics_killmails/up.sql
@@ -1,0 +1,15 @@
+CREATE TABLE analytics_killmails (
+    killmail_id BIGINT NOT NULL,
+    killmail_hash TEXT NOT NULL,
+
+    fitted_value DOUBLE PRECISION DEFAULT 0,
+    destroyed_value DOUBLE PRECISION DEFAULT 0,
+    dropped_value DOUBLE PRECISION DEFAULT 0,
+    total_value DOUBLE PRECISION DEFAULT 0,
+    attacker_count INT DEFAULT 0,
+
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+
+    PRIMARY KEY (killmail_id, killmail_hash)
+)

--- a/src/filters/tests.rs
+++ b/src/filters/tests.rs
@@ -711,9 +711,7 @@ mod config_tests {
 
         let killmail = Killmail {
             kill_id: 1,
-            zkb: Zkb {
-                href: "".to_string(),
-            },
+            zkb: Default::default(),
             killmail: Some(KillmailData {
                 system_id: 30000142, // system in region 10000002
                 attackers: vec![crate::zkb::Participant {
@@ -758,9 +756,7 @@ mod config_tests {
 
         let killmail_include = Killmail {
             kill_id: 1,
-            zkb: Zkb {
-                href: "".to_string(),
-            },
+            zkb: Default::default(),
             killmail: Some(KillmailData {
                 system_id: 30000142, // system in region 10000002
                 attackers: vec![crate::zkb::Participant {
@@ -813,9 +809,7 @@ mod config_tests {
 
         let km = Killmail {
             kill_id: 1,
-            zkb: Zkb {
-                href: "".to_string(),
-            },
+            zkb: Default::default(),
             killmail: Some(KillmailData {
                 attackers: vec![crate::zkb::Participant {
                     corporation_id: Some(100000),
@@ -835,9 +829,7 @@ mod config_tests {
 
         let km = Killmail {
             kill_id: 2,
-            zkb: Zkb {
-                href: "".to_string(),
-            },
+            zkb: Default::default(),
             killmail: Some(KillmailData {
                 victim: crate::zkb::Participant {
                     ship_type_id: Some(20002),
@@ -857,9 +849,7 @@ mod config_tests {
 
         let km = Killmail {
             kill_id: 3,
-            zkb: Zkb {
-                href: "".to_string(),
-            },
+            zkb: Default::default(),
             killmail: Some(KillmailData {
                 system_id: 30000142,
                 ..Default::default()
@@ -876,9 +866,7 @@ mod config_tests {
 
         let km = Killmail {
             kill_id: 4,
-            zkb: Zkb {
-                href: "".to_string(),
-            },
+            zkb: Default::default(),
             killmail: Some(KillmailData {
                 system_id: 30000142,
                 attackers: vec![crate::zkb::Participant {

--- a/src/main.rs
+++ b/src/main.rs
@@ -180,10 +180,7 @@ async fn main() -> anyhow::Result<()> {
             }
 
             let cache_key = format!("kill:global:{}", killmail.kill_id);
-            let cache_hit = match cache.check(&cache_key) {
-                Ok(hit) => hit,
-                Err(_) => false,
-            };
+            let cache_hit = cache.check(&cache_key).unwrap_or_default();
 
             if !cache_hit {
                 if let Err(e) = persistence.add_analytics_data(&killmail.zkb) {

--- a/src/persistence/mod.rs
+++ b/src/persistence/mod.rs
@@ -1,4 +1,4 @@
-use crate::filters::FilterSet;
+use crate::{filters::FilterSet, zkb::Zkb};
 
 pub mod cache;
 pub mod provider;
@@ -21,4 +21,6 @@ pub trait Store: Send + Sync {
     fn remove_filter_from_set(&self, channel_id: u64, filter: &str) -> Result<(), anyhow::Error>;
 
     fn clear_filter_set(&self, channel_id: u64) -> Result<(), anyhow::Error>;
+
+    fn add_analytics_data(&self, km: &Zkb) -> Result<(), anyhow::Error>;
 }

--- a/src/persistence/provider/memory.rs
+++ b/src/persistence/provider/memory.rs
@@ -109,6 +109,13 @@ impl crate::persistence::Store for Store {
             Err(anyhow::anyhow!("failed to acquire write lock"))
         }
     }
+
+    fn add_analytics_data(&self, km: &crate::zkb::Zkb) -> Result<(), anyhow::Error> {
+        tracing::debug!(?km, "adding analytics data to memory (no-op)");
+
+        // No-op for Redis store
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/src/persistence/provider/mod.rs
+++ b/src/persistence/provider/mod.rs
@@ -1,3 +1,3 @@
 pub mod memory;
-pub mod redis;
 pub mod postgres;
+pub mod redis;

--- a/src/persistence/provider/postgres/mod.rs
+++ b/src/persistence/provider/postgres/mod.rs
@@ -151,7 +151,7 @@ impl crate::persistence::Store for Store {
         tracing::debug!(
             channel_id,
             filter = filter,
-            provider="postgres",
+            provider = "postgres",
             "removing filter from set"
         );
 
@@ -179,7 +179,7 @@ impl crate::persistence::Store for Store {
     }
 
     fn clear_filter_set(&self, channel_id: u64) -> Result<(), anyhow::Error> {
-        tracing::debug!(channel_id, provider="postgres", "clearing filter set");
+        tracing::debug!(channel_id, provider = "postgres", "clearing filter set");
 
         use crate::persistence::provider::postgres::schema::filter_sets::dsl;
 
@@ -207,7 +207,7 @@ impl crate::persistence::Store for Store {
         };
 
         let new_analytics_km = model::AnalyticsKillmails {
-            killmail_id: killmail_id,
+            killmail_id,
             killmail_hash: km.hash.clone(),
             fitted_value: Some(km.fitted_value),
             destroyed_value: Some(km.destroyed_value),
@@ -240,7 +240,8 @@ mod tests {
     #[test]
     #[ignore]
     fn test_postgres_store() {
-        let store = Store::new("postgres://postgres:postgres@127.0.0.1/postgres").expect("Failed to connect to Postgres");
+        let store = Store::new("postgres://postgres:postgres@127.0.0.1/postgres")
+            .expect("Failed to connect to Postgres");
         // Clean up any existing test data
         let _ = store.clear_filter_set(20);
 

--- a/src/persistence/provider/postgres/model.rs
+++ b/src/persistence/provider/postgres/model.rs
@@ -1,5 +1,5 @@
-use diesel::prelude::*;
 use crate::persistence::provider::postgres::schema;
+use diesel::prelude::*;
 
 #[derive(Queryable, Selectable, Insertable, Clone)]
 #[diesel(table_name = schema::filter_sets)]

--- a/src/persistence/provider/postgres/model.rs
+++ b/src/persistence/provider/postgres/model.rs
@@ -11,3 +11,18 @@ pub struct FilterSet {
     pub created_at: Option<chrono::NaiveDateTime>,
     pub updated_at: Option<chrono::NaiveDateTime>,
 }
+
+#[derive(Queryable, Insertable, Clone)]
+#[diesel(table_name = schema::analytics_killmails)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct AnalyticsKillmails {
+    pub killmail_id: i64,
+    pub killmail_hash: String,
+    pub fitted_value: Option<f64>,
+    pub destroyed_value: Option<f64>,
+    pub dropped_value: Option<f64>,
+    pub total_value: Option<f64>,
+    pub attacker_count: Option<i32>,
+    pub created_at: Option<chrono::NaiveDateTime>,
+    pub updated_at: Option<chrono::NaiveDateTime>,
+}

--- a/src/persistence/provider/postgres/schema.rs
+++ b/src/persistence/provider/postgres/schema.rs
@@ -1,6 +1,20 @@
 // @generated automatically by Diesel CLI.
 
 diesel::table! {
+    analytics_killmails (killmail_id, killmail_hash) {
+        killmail_id -> Int8,
+        killmail_hash -> Text,
+        fitted_value -> Nullable<Float8>,
+        destroyed_value -> Nullable<Float8>,
+        dropped_value -> Nullable<Float8>,
+        total_value -> Nullable<Float8>,
+        attacker_count -> Nullable<Int4>,
+        created_at -> Timestamp,
+        updated_at -> Timestamp,
+    }
+}
+
+diesel::table! {
     filter_sets (channel_id) {
         channel_id -> Int8,
         guild_id -> Int8,
@@ -9,3 +23,5 @@ diesel::table! {
         updated_at -> Nullable<Timestamptz>,
     }
 }
+
+diesel::allow_tables_to_appear_in_same_query!(analytics_killmails, filter_sets,);

--- a/src/persistence/provider/redis.rs
+++ b/src/persistence/provider/redis.rs
@@ -195,6 +195,13 @@ impl crate::persistence::Store for Store {
 
         Ok(())
     }
+
+    fn add_analytics_data(&self, km: &crate::zkb::Zkb) -> Result<(), anyhow::Error> {
+        tracing::debug!(?km, "adding analytics data to redis (no-op)");
+
+        // No-op for Redis store
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/src/zkb.rs
+++ b/src/zkb.rs
@@ -27,12 +27,11 @@ pub struct Zkb {
 impl Zkb {
     pub fn killmail_id(&self) -> Option<u64> {
         let re = regex::Regex::new(r"/killmails/(\d+)/").unwrap();
-        if let Some(caps) = re.captures(&self.href) {
-            if let Some(matched) = caps.get(1) {
-                if let Ok(id) = matched.as_str().parse::<u64>() {
-                    return Some(id);
-                }
-            }
+        if let Some(caps) = re.captures(&self.href)
+            && let Some(matched) = caps.get(1)
+            && let Ok(id) = matched.as_str().parse::<u64>()
+        {
+            return Some(id);
         }
         None
     }

--- a/src/zkb.rs
+++ b/src/zkb.rs
@@ -11,6 +11,45 @@ pub struct Response {
 #[derive(Debug, serde::Deserialize)]
 pub struct Zkb {
     pub href: String,
+    pub hash: String,
+    #[serde(rename = "fittedValue")]
+    pub fitted_value: f64,
+    #[serde(rename = "destroyedValue")]
+    pub destroyed_value: f64,
+    #[serde(rename = "droppedValue")]
+    pub dropped_value: f64,
+    #[serde(rename = "totalValue")]
+    pub total_value: f64,
+    #[serde(rename = "attackerCount")]
+    pub attacker_count: u64,
+}
+
+impl Zkb {
+    pub fn killmail_id(&self) -> Option<u64> {
+        let re = regex::Regex::new(r"/killmails/(\d+)/").unwrap();
+        if let Some(caps) = re.captures(&self.href) {
+            if let Some(matched) = caps.get(1) {
+                if let Ok(id) = matched.as_str().parse::<u64>() {
+                    return Some(id);
+                }
+            }
+        }
+        None
+    }
+}
+
+impl Default for Zkb {
+    fn default() -> Self {
+        Self {
+            href: String::new(),
+            hash: String::new(),
+            fitted_value: 0.0,
+            destroyed_value: 0.0,
+            dropped_value: 0.0,
+            total_value: 0.0,
+            attacker_count: 0,
+        }
+    }
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -94,5 +133,20 @@ pub struct Participant {
 impl Participant {
     pub fn is_npc(&self) -> bool {
         self.character_id.is_none()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_zkb_killmail_id_extraction() {
+        let zkb = Zkb {
+            href: "https://esi.evetech.net/killmails/132171502/f92138513e5e6f1ff78151b810a7688ae577155f/".to_string(),
+            ..Default::default()
+        };
+
+        assert_eq!(zkb.killmail_id(), Some(132171502));
     }
 }


### PR DESCRIPTION
Why: I want to implement a way to generate reports from activities broken down by date, participants, location, etc. In order to do that we need to save killmail data.

What: Save data for killmails that matched any filters